### PR TITLE
Types QOL

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,8 @@
-import { AiTextGenerationToolInput } from "@cloudflare/workers-types";
+import {
+	AiTextGenerationToolInput,
+	type AiTextGenerationOutput,
+	type ReadableStream,
+} from "@cloudflare/workers-types";
 import { JSONSchema7 } from "json-schema";
 
 export type UppercaseHttpMethod =
@@ -91,3 +95,8 @@ export function tool<T extends JSONSchema7>(
 ): ToolsSchema<T> {
 	return tool;
 }
+
+export type NonStreamingAiTextGenerationOutput = Exclude<
+	AiTextGenerationOutput,
+	ReadableStream
+>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,8 @@ import {
 	Ai,
 	BaseAiTextGenerationModels,
 	RoleScopedChatInput,
+	type AiTextGenerationOutput,
+	type ReadableStream,
 } from "@cloudflare/workers-types";
 
 export async function fetchSpec(
@@ -130,16 +132,8 @@ export async function autoTrimTools(
 			],
 			stream: false,
 			tools: [{ type: "function", function: chooseTools }],
-		})) as {
-			response?: string;
-			tool_calls?: {
-				// For now, I couldn't find a reliable way to remove the ReadableStream type from the union.
-				name: string;
-				arguments: {
-					tools: string[];
-				};
-			}[];
-		};
+			// `ReadableStream` needs to be imported from `@cloudflare/workers-types` because that's the one used in the definition of `AiTextGenerationOutput`
+		})) as Exclude<AiTextGenerationOutput, ReadableStream>;
 
 		// Filter the chosen tool calls from the response
 		const chooseToolCalls = toolsResponse.tool_calls?.filter(Boolean);


### PR DESCRIPTION
Can use `Exclude<>` to remove `ReadableStream` from union. However to keep the typed `arguments` for `autoTrimTools()`, I had to resort to some chained `Omit<>` to override the upstream `unknown` type.

Side note: Since zod is parsing the structure, could we use its infer type to auto type `arguments`?