### PR TITLE
Add max_tokens parameter support to runWithTools

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,8 @@
 	],
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
-	"dependencies": {},
 	"devDependencies": {
-		"@cloudflare/workers-types": "^4.20240620.0",
+		"@cloudflare/workers-types": "^4.20251003.0",
 		"@types/json-schema": "^7.0.15",
 		"@types/node": "^20.14.8",
 		"esbuild": "^0.21.5",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,10 @@
-import { AiTextGenerationToolInput } from "@cloudflare/workers-types";
+import { AiTextGenerationToolInput, AiModels } from "@cloudflare/workers-types";
 import { JSONSchema7 } from "json-schema";
+
+/**
+ * Model names available in Workers AI
+ */
+export type ModelName = keyof AiModels;
 
 export type UppercaseHttpMethod =
 	| "GET"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,10 +3,9 @@ import { OpenAPIV3 } from "./types/openapi-schema";
 import { JSONSchema7 } from "json-schema";
 import { ZodTypeAny, z } from "zod";
 import { Logger } from "./logger";
-import { AiTextGenerationToolInputWithFunction } from "./types";
+import { AiTextGenerationToolInputWithFunction, ModelName } from "./types";
 import {
 	Ai,
-	BaseAiTextGenerationModels,
 	RoleScopedChatInput,
 } from "@cloudflare/workers-types";
 
@@ -92,7 +91,7 @@ export function validateArgsWithZod(
 export async function autoTrimTools(
 	tools: AiTextGenerationToolInputWithFunction[],
 	ai: Ai,
-	model: BaseAiTextGenerationModels,
+	model: ModelName,
 	messages: RoleScopedChatInput[],
 ) {
 	let returnedTools = tools;


### PR DESCRIPTION
  **Description:**

 This adds support for controlling the maximum number of tokens in AI responses by passing an optional max_tokens parameter to runWithTools.

  **Problem:**
  The default token limit of 256 causes response truncation for longer outputs. There's currently no way to configure this.

  **Solution:**
  - Add max_tokens parameter to runWithTools input options
  - Pass max_tokens to both AI.run() calls (initial and final response)
  - Create shared ModelName type (keyof AiModels) to replace non-existent BaseAiTextGenerationModels
  - Update type references in runWithTools.ts and utils.ts

  **Usage:**
```typescript
  const response = await runWithTools(
    env.AI,
    '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
    {
      messages,
      tools: [searchTool],
      max_tokens: 2048,  // Now supported
    }
  );

```
  **Testing:**
Tested in production with personal application. Prevents truncation of longer AI responses while maintaining backward
  compatibility (parameter is optional).